### PR TITLE
Inconsistent use of "Prepare"

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -150,7 +150,7 @@ This includes:
 
 ### 7.1 Prepare (Provider)
 
-TBD - Systems used in the Prepare stage SHALL NOT be included in Provider SCI calculations is confirmed and retained.
+TBD - Systems used in the Prepare stage SHALL NOT be included in the Provider SCI calculation since they are not material to the total carbon emissions.
 
 ### 7.2 Data Engineering (Provider)
 


### PR DESCRIPTION
Inconsistent treatment of the "Prepare" phase across the current draft spec

See #45