### PR TITLE
fix: correct Provider SCI value from 30 to 3000 kg CO₂e/billion parameters

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -331,7 +331,7 @@ For a computer vision model used for image classification:
 **Example**:
 - Total Provider emissions: 75,000 kg CO₂e
 - Total parameters: 2.5 billion
-- Provider SCI = 30 kg CO₂e/billion parameters
+- Provider SCI = 3000 kg CO₂e/billion parameters
 
 #### 9.2.3 Reporting
 


### PR DESCRIPTION
Fixes #100

This PR addresses the incorrect value identified in issue #100. The Provider SCI value in SPEC.md has been corrected from 30 to 3000 kg CO₂e/billion parameters as suggested.

Generated with [Claude Code](https://claude.ai/code)