### PR TITLE
fix: correct Consumer SCI values to 130 kg CO₂e/billion tokens

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -276,7 +276,7 @@ For a typical Large Language Model service, two separate SCI scores should be ca
 - Total Consumer operational carbon: 5,000 kg CO₂e/week
 - Total Consumer embodied carbon: 1,500 kg CO₂e/week
 - Total tokens processed: 50 billion tokens/week
-- Consumer SCI = 6,500 kg CO₂e / 50 billion tokens = 130 g CO₂e/million tokens
+- Consumer SCI = 6,500 kg CO₂e / 50 billion tokens = 130 kg CO₂e/billion tokens
 
 #### 9.1.2 Provider SCI Calculation
 
@@ -304,7 +304,7 @@ For a typical Large Language Model service, two separate SCI scores should be ca
 #### 9.1.3 Reporting
 
 The LLM would report both SCI values:
-- **Consumer SCI**: 0.13 g CO₂e/million tokens
+- **Consumer SCI**: 130 kg CO₂e/billion tokens
 - **Provider SCI**: 4 g CO₂e/10¹⁸ FLOPs
 
 ### 9.2 Computer Vision Model Example


### PR DESCRIPTION
This fixes the unit inconsistency identified in issue #98 where lines 279 and 307 had different units and values for the Consumer SCI calculation.

Changes:
- Line 279: Updated from "130 g CO₂e/million tokens" to "130 kg CO₂e/billion tokens"
- Line 307: Updated from "0.13 g CO₂e/million tokens" to "130 kg CO₂e/billion tokens"

Both values are mathematically equivalent but now use consistent units.

Closes #98

🤖 Generated with [Claude Code](https://claude.ai/code)