### PR TITLE
Align AI lifecycle vocabulary with ISO/IEC standards

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -89,8 +89,8 @@ If a single metric tried to combine everything, it would dilute accountability a
 
 The lifecycle stages are assigned to personas based on their typical control and agency:
 
-- **Providers** (companies that build AI systems) control the emissions from Prepare, Data Engineering, Model Training, System Integration, and End of Life stages.
-- **Consumers** (organizations and individuals who use AI systems) control the emissions from Runtime Operations.
+- **Providers** (companies that build AI systems) control the emissions from Inception, Design and Development, Deployment, and Retirement stages.
+- **Consumers** (organizations and individuals who use AI systems) control the emissions from Operation and Monitoring.
 
 This alignment ensures that each persona's SCI score reflects only the emissions they can reasonably influence or control.
 
@@ -177,7 +177,7 @@ These insights enable meaningful target-setting. If you've just finished trainin
 
 Training emissions are included in the Provider SCI calculation only. This is because:
 
-1. Training is part of the Model Training lifecycle stage, which is assigned to the Provider boundary
+1. Training is part of the Design and Development lifecycle stage, which is assigned to the Provider boundary
 2. Providers have direct control over training methodologies, hardware selection, and efficiency optimizations
 3. It creates clear accountability for the emissions produced during the creation of AI models
 
@@ -209,9 +209,9 @@ The comprehensive lifecycle approach:
 - Aligns with established lifecycle assessment methodologies
 - Enables more complete and accurate comparisons between AI systems
 
-#### Why separate Model Training from System Integration?
+#### Why is model training included in the Design and Development stage?
 
-Model Training is separated as its own lifecycle stage because:
+Model training is included in the Design and Development stage because:
 1. It often represents a significant portion of an AI system's carbon footprint
 2. It involves unique considerations around resource allocation and optimization
 3. It's a key area of focus for emissions reduction efforts
@@ -270,12 +270,11 @@ During development, we agreed to evaluate SCI for AI and existing metrics agains
 - **Existing Standards Alignment**: Does it align with established practices like LCA or GHG Protocol?
 
 **Lifecycle Coverage:**
-- Prepare
-- Data Engineering
-- Model Training
-- System Integration
-- Runtime Operations
-- End of Life
+- Inception
+- Design and Development
+- Deployment
+- Operation and Monitoring
+- Retirement
 
 **Incentivization:**
 - Does it encourage infrastructure efficiency improvements?
@@ -300,12 +299,11 @@ Here's how SCI for AI compares to other metrics based on these criteria:
 | **ISO Compatibility**             | ✅          | ❓              | ❓         | ❌            |
 | **IPR Clarity**                   | ✅          | ❌              | ❌         | ❌            |
 | **Existing Standards Alignment**  | ✅          | ✅              | ✅         | ❌            |
-| **Lifecycle: Prepare**            | ✅          | ❌              | ❌         | ❌            |
-| **Lifecycle: Data Engineering**   | ✅          | ❌              | ❌         | ❌            |
-| **Lifecycle: Model Training**     | ✅          | ✅              | ❌         | ❌            |
-| **Lifecycle: System Integration** | ✅          | ❌              | ❌         | ❌            |
-| **Lifecycle: Runtime Operations** | ✅          | ✅              | ☑️*        | ☑️**          |
-| **Lifecycle: End of Life**        | ✅          | ❌              | ❌         | ❌            |
+| **Lifecycle: Inception**          | ✅          | ❌              | ❌         | ❌            |
+| **Lifecycle: Design and Development** | ✅      | ✅              | ❌         | ❌            |
+| **Lifecycle: Deployment**         | ✅          | ❌              | ❌         | ❌            |
+| **Lifecycle: Operation and Monitoring** | ✅    | ✅              | ☑️*        | ☑️**          |
+| **Lifecycle: Retirement**         | ✅          | ❌              | ❌         | ❌            |
 
 *EcoLogits only accounts for computation of GPU-equipped servers, omitting other runtime infrastructure
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -92,23 +92,20 @@ Basic computational operation used as a measure of computational work in AI syst
 ## 5. AI Lifecycle Stages
 For the purpose of measuring carbon emissions, the AI lifecycle is divided into the following stages:
 
-### 5.1 Prepare
-The Prepare stage involves defining the AI problem, assessing whether AI is the appropriate solution, engaging with end-users, and establishing performance objectives and computational constraints.
+### 5.1 Inception
+The Inception stage involves defining the AI problem, assessing whether AI is the appropriate solution, engaging with end-users, and establishing performance objectives and computational constraints.
 
-### 5.2 Data Engineering
-The Data Engineering stage includes data collection from various sources, preprocessing (cleaning and normalizing), and generating synthetic data when appropriate to reduce the need for excessive data collection.
+### 5.2 Design and Development
+The Design and Development stage includes data collection from various sources, preprocessing (cleaning and normalizing), generating synthetic data when appropriate to reduce the need for excessive data collection, model selection, feature engineering, distributed training setup, evaluation metric definition, resource allocation, benchmarking, and computational resource optimization.
 
-### 5.3 Model Training
-The Model Training stage encompasses model selection, feature engineering, distributed training setup, evaluation metric definition, resource allocation, benchmarking, and computational resource optimization.
+### 5.3 Deployment
+The Deployment stage involves incorporating the AI model into larger systems, designing component interactions, connecting with external applications, and testing for integration errors before deployment.
 
-### 5.4 System Integration
-The System Integration stage involves incorporating the AI model into larger systems, designing component interactions, connecting with external applications, and testing for integration errors before deployment.
+### 5.4 Operation and Monitoring
+The Operation and Monitoring stage includes model deployment for inference, orchestration of autonomous workflows and models (e.g., in Agentic AI), integration of model tools and services, monitoring performance metrics, implementing maintenance protocols, and applying FinOps practices across edge devices, data centers, and cloud environments.
 
-### 5.5 Runtime Operations
-The Runtime Operations stage includes model deployment for inference, orchestration of autonomous workflows and models (e.g., in Agentic AI), integration of model tools and services, monitoring performance metrics, implementing maintenance protocols, and applying FinOps practices across edge devices, data centers, and cloud environments.
-
-### 5.6 End of Life
-The End of Life stage involves decommissioning AI systems no longer maintained in runtime environments and properly handling associated resources and data.
+### 5.5 Retirement
+The Retirement stage involves decommissioning AI systems no longer maintained in runtime environments and properly handling associated resources and data.
 
 ## 6. Persona-Based Software Boundary Definition
 
@@ -116,7 +113,7 @@ The SCI for AI specification defines boundaries based on two primary personas, e
 
 ### 6.1 Consumer Boundary
 
-The Consumer boundary SHALL include all components related to the Runtime Operations lifecycle stage, including but not limited to:
+The Consumer boundary SHALL include all components related to the Operation and Monitoring lifecycle stage, including but not limited to:
 
 - API & Inference
 - Orchestration
@@ -131,10 +128,9 @@ The Consumer boundary SHALL include all components related to the Runtime Operat
 ### 6.2 Provider Boundary
 
 The Provider boundary SHALL include all components related to the following lifecycle stages:
-- Data Engineering
-- Model Training
-- System Integration
-- End of Life/Disposal
+- Design and Development
+- Deployment
+- Retirement
 
 This includes:
 - Project Scoping & Planning Systems
@@ -152,35 +148,33 @@ This includes:
 
 ## 7. AI Life Cycle Coverage
 
-### 7.1 Prepare (Provider)
+### 7.1 Inception (Provider)
 
-Systems used in the Prepare stage SHALL be included in the Provider SCI calculation when material; they MAY be included when not material.
+Systems used in the Inception stage SHALL be included in the Provider SCI calculation when material; they MAY be included when not material.
 
-### 7.2 Data Engineering (Provider)
+### 7.2 Design and Development (Provider)
 
-All carbon emissions associated with systems used in the Data Engineering stage SHALL be included in the Provider SCI calculation.
-
-### 7.3 Model Training (Provider)
-
-All carbon emissions associated with Model Training SHALL be included in the Provider SCI calculation, including:
-- Compute, storage, and networking resources
+All carbon emissions associated with systems used in the Design and Development stage SHALL be included in the Provider SCI calculation, including:
+- Data collection, preprocessing, and cleaning systems
+- Synthetic data generation
+- Compute, storage, and networking resources for model training
 - Distributed training infrastructure
 - Model selection and benchmarking systems
 - Evaluation frameworks
 
-Emissions from model training SHALL be calculated over the entire training duration, including but not limited to, accounting for all epochs, parameter updates, intermediate runs, and early stopping phases. 
+Emissions from model training SHALL be calculated over the entire training duration, including but not limited to, accounting for all epochs, parameter updates, intermediate runs, and early stopping phases.
 
-### 7.4 System Integration (Provider)
+### 7.3 Deployment (Provider)
 
-All carbon emissions associated with System Integration SHALL be included in the Provider SCI calculation.
+All carbon emissions associated with Deployment SHALL be included in the Provider SCI calculation.
 
-### 7.5 Runtime Operations (Consumer)
+### 7.4 Operation and Monitoring (Consumer)
 
-All carbon emissions associated with systems used in the Runtime Operations stage SHALL be included in the Consumer SCI calculation.
+All carbon emissions associated with systems used in the Operation and Monitoring stage SHALL be included in the Consumer SCI calculation.
 
-### 7.6 End of Life
+### 7.5 Retirement
 
-Systems used in the End of Life stage SHALL be included in the SCI calculation when material; they MAY be included when not material.
+Systems used in the Retirement stage SHALL be included in the SCI calculation when material; they MAY be included when not material.
 
 ## 8. Functional Units
 
@@ -259,7 +253,7 @@ For a typical Large Language Model service, two separate SCI scores should be ca
 
 **Functional Unit**: Per Token
 
-**Boundary**: Runtime Operations (inference services, API infrastructure, monitoring systems)
+**Boundary**: Operation and Monitoring (inference services, API infrastructure, monitoring systems)
 
 **Calculation Method**:
 1. Measure all operational carbon within the Consumer boundary over a defined period (e.g., one week):
@@ -282,7 +276,7 @@ For a typical Large Language Model service, two separate SCI scores should be ca
 
 **Functional Unit**: Per FLOP, Per Parameter, or Per Training Token (example uses Per FLOP)
 
-**Boundary**: Data Engineering, Model Training, System Integration, End of Life
+**Boundary**: Design and Development, Deployment, Retirement
 
 **Calculation Method**:
 1. Measure all operational carbon within the Provider boundary:
@@ -315,7 +309,7 @@ For a computer vision model used for image classification:
 
 **Functional Unit**: Per Inference
 
-**Boundary**: Runtime Operations
+**Boundary**: Operation and Monitoring
 
 **Example**:
 - Total Consumer emissions: 3,200 kg CO₂e/month
@@ -326,7 +320,7 @@ For a computer vision model used for image classification:
 
 **Functional Unit**: Per Parameter
 
-**Boundary**: Prepare, Data Engineering, Model Training, System Integration, End of Life
+**Boundary**: Inception, Design and Development, Deployment, Retirement
 
 **Example**:
 - Total Provider emissions: 75,000 kg CO₂e


### PR DESCRIPTION
Updates lifecycle stage terminology in sections 5 & 7 to align with ISO/IEC 22989:2022 and ISO/IEC 5338:2023:

- Prepare → Inception
- Data Engineering + Model Training → Design and Development
- System Integration → Deployment
- Runtime Operations → Operation and Monitoring
- End of Life → Retirement

Updated SPEC.md sections 5, 6, 7, and 9 with new vocabulary.
Updated FAQ.md to reflect terminology changes and maintain consistency.

Resolves #91

🤖 Generated with [Claude Code](https://claude.ai/code)