### PR TITLE
Fix reporting phrasing in section 9

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -303,7 +303,7 @@ For a typical Large Language Model service, two separate SCI scores should be ca
 
 #### 9.1.3 Reporting
 
-The LLM would report both SCI values:
+For an LLM the following SCI values can be reported:
 - **Consumer SCI**: 0.13 g CO₂e/million tokens
 - **Provider SCI**: 4 g CO₂e/10¹⁸ FLOPs
 
@@ -335,6 +335,6 @@ For a computer vision model used for image classification:
 
 #### 9.2.3 Reporting
 
-The computer vision model would report both SCI values:
+For a computer vision model the following SCI values can be reported:
 - **Consumer SCI**: 0.08 g CO₂e/inference
 - **Provider SCI**: 30 kg CO₂e/billion parameters


### PR DESCRIPTION
This PR addresses issue #92 by improving the reporting phrasing in section 9.

**Changes made:**
- Changed "The LLM would report both SCI values:" to "For an LLM the following SCI values can be reported:"
- Changed "The computer vision model would report both SCI values:" to "For a computer vision model the following SCI values can be reported:"

This clarifies that it's not the AI model itself reporting values, but rather what values can be reported for the model.

Fixes #92

Generated with [Claude Code](https://claude.ai/code)