### PR TITLE
Fix Runtime Operations to Operation and Monitoring consistency

### DIFF
--- a/ANCILLARY.md
+++ b/ANCILLARY.md
@@ -170,7 +170,7 @@ Specifically they defined these life cycle stages which apply to Green AI and th
 
 * **System Integration**: Design, develop, and test the distributed end-to-end runtime environment in which the model will be deployed.
 
-* **Runtime Operations**: The execution of the model in a runtime environment, including inference, maintenance, monitoring, consumer edge devices and datacenter/cloud usage.
+* **Operation and Monitoring**: The execution of the model in a runtime environment, including inference, maintenance, monitoring, consumer edge devices and datacenter/cloud usage.
 
 * **End of Life**: “Un-deploy” the model in the runtime environment. 
 
@@ -182,7 +182,7 @@ The SCI measure SHALL incentivise optimisations at each stage of this lifecycle.
 | Data Engineering | ❌ | ❌ | ❌ | ❌ |
 | Model training | ✅ | ❌ | ❌ | ✅ |
 | System integration | ❌ | ❌ | ❌ | ❌ |
-| Runtime operations | ✅ | ☑️ | ☑️ | ✅ |
+| Operation and Monitoring | ✅ | ☑️ | ☑️ | ✅ |
 | End of life | ❌ | ❌ | ❌ | ❌ |
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -194,7 +194,7 @@ We decided not to include training emissions in the Consumer SCI calculation for
 1. **Clear Boundaries**: Keeping training emissions solely within the Provider boundary maintains clean, non-overlapping responsibility areas
 2. **Agency Alignment**: Consumers typically have no control over how models are trained
 3. **Measurement Simplicity**: Separating training from inference creates more straightforward measurement methodologies
-4. **Incentive Clarity**: It focuses Consumer attention on what they can control - the efficiency of runtime operations
+4. **Incentive Clarity**: It focuses Consumer attention on what they can control - the efficiency of operation and monitoring
 
 > [!IMPORTANT] 
 > This doesn't mean training emissions are ignored - they're captured in the Provider SCI score, which Consumers can consider when selecting AI systems alongside the Consumer SCI score.

--- a/SPEC.md
+++ b/SPEC.md
@@ -104,11 +104,8 @@ The Deployment stage involves incorporating the AI model into larger systems, de
 ### 5.4 Operation and Monitoring
 The Operation and Monitoring stage includes model deployment for inference, orchestration of autonomous workflows and models (e.g., in Agentic AI), integration of model tools and services, monitoring performance metrics, implementing maintenance protocols, and applying FinOps practices across edge devices, data centers, and cloud environments.
 
-### 5.5 Runtime Operations
-The Runtime Operations stage includes model deployment for inference, orchestration of autonomous workflows and models (e.g., in Agentic AI), integration of model tools and services, monitoring performance metrics, implementing maintenance protocols, and applying practices, like FinOps, across edge devices, data centers, and cloud environments.
-
-### 5.6 End of Life
-The End of Life stage involves decommissioning AI systems no longer maintained in runtime environments and properly handling associated resources and data.
+### 5.5 Retirement
+The Retirement stage involves decommissioning AI systems no longer maintained in runtime environments and properly handling associated resources and data.
 
 ## 6. Persona-Based Software Boundary Definition
 


### PR DESCRIPTION
Remove duplicate section 5.5 Runtime Operations from SPEC.md and ensure all references consistently use "Operation and Monitoring" terminology throughout the specification.

Changes:
- Remove duplicate section 5.5 Runtime Operations from SPEC.md 
- Update section numbering (5.6 End of Life → 5.5 Retirement)
- Update ANCILLARY.md lifecycle stage name and table reference
- Update FAQ.md reference to use consistent terminology

Resolves the inconsistency where both "Runtime Operations" and "Operation and Monitoring" appeared in the specification for the same lifecycle stage.

Resolves #91

🤖 Generated with [Claude Code](https://claude.ai/code)